### PR TITLE
fix: Don't attempt to parse body on 204 response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,10 @@ export class createClient {
       ...(data && body)
     })
 
+    // No JSON body if a delete response
+    if(response.status === 204)
+      return response.text()
+
     const json = await response.json()
 
     if (!response.ok) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,6 @@ export class createClient {
       ...(data && body)
     })
 
-    // No JSON body if a delete response
     if(response.status === 204)
       return response.text()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export class createClient {
       ...(data && body)
     })
 
-    if(response.status === 204)
+    if (response.status === 204)
       return response.text()
 
     const json = await response.json()


### PR DESCRIPTION
Currently the library will return an error if a 204 no content response is returned from the API.

It does this because it immediately tries to parse a JSON response.

This change ensures that if the response code is a 204, no parsing attempt is made, and any response text is still returned.