### PR TITLE
breaking change: rename createClient to MoltinClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ yarn add @moltin/request # npm install @moltin/request
 ## Quickstart (implicit)
 
 ```js
-const { createClient } = require('@moltin/request')
-// import { createClient } from '@moltin/request'
+const MoltinClient = require('@moltin/request')
+// import MoltinClient from '@moltin/request'
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: '...'
 })
 
@@ -31,10 +31,10 @@ client
 ⚠️ You should not use client credentials on the client-side. You will expose your client secret, read more about authentication [here](https://docs.moltin.com/basics/authentication).
 
 ```js
-const { createClient } = require('@moltin/request')
-// import { createClient } from '@moltin/request'
+const MoltinClient = require('@moltin/request')
+// import MoltinClient from '@moltin/request'
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: '...',
   client_secret: '...'
 })
@@ -68,10 +68,10 @@ To prevent unnecessary authentication requests, you will want to use a storage a
 ### Node Local Storage
 
 ```js
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 const NodeStorageAdapter = require('@moltin/node-storage-adapter')
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: '...',
   storage: new NodeStorageAdapter('./localStorage')
 })
@@ -87,10 +87,10 @@ client
 This library uses [cross-fetch](https://github.com/lquixada/cross-fetch) to make requests. If you wish to change this library, you can pass a custom fetch when instantiating a new moltin client.
 
 ```js
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 const fetchEverywhere = require('fetch-everywhere')
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: '...',
   fetch: fetchEverywhere
 })
@@ -104,10 +104,10 @@ client
 ## Kitchen sink
 
 ```js
-const { createClient } = require('@moltin/request')
-// import { createClient } from '@moltin/request'
+const MoltinClient = require('@moltin/request')
+// import MoltinClient from '@moltin/request'
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: '...',
   client_secret: '...',
   fetch: customFetch,
@@ -134,9 +134,9 @@ This argument can be used to get products by enabled currency, language or even 
 **Note**: If you add the `Content-Type` custom header to `post`, `put` or `delete` you will need to encode `data` yourself.
 
 ```js
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: '...'
 })
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ yarn add @moltin/request # npm install @moltin/request
 
 ```js
 const { MoltinClient } = require('@moltin/request')
-// import {MoltinClient} from '@moltin/request'
+// import { MoltinClient } from '@moltin/request'
 
 const client = new MoltinClient({
   client_id: '...'
@@ -32,7 +32,7 @@ client
 
 ```js
 const { MoltinClient } = require('@moltin/request')
-// import {MoltinClient} from '@moltin/request'
+// import { MoltinClient } from '@moltin/request'
 
 const client = new MoltinClient({
   client_id: '...',
@@ -105,7 +105,7 @@ client
 
 ```js
 const { MoltinClient } = require('@moltin/request')
-// import {MoltinClient} from '@moltin/request'
+// import { MoltinClient } from '@moltin/request'
 
 const client = new MoltinClient({
   client_id: '...',

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ yarn add @moltin/request # npm install @moltin/request
 ## Quickstart (implicit)
 
 ```js
-const MoltinClient = require('@moltin/request')
-// import MoltinClient from '@moltin/request'
+const { MoltinClient } = require('@moltin/request')
+// import {MoltinClient} from '@moltin/request'
 
 const client = new MoltinClient({
   client_id: '...'
@@ -31,8 +31,8 @@ client
 ⚠️ You should not use client credentials on the client-side. You will expose your client secret, read more about authentication [here](https://docs.moltin.com/basics/authentication).
 
 ```js
-const MoltinClient = require('@moltin/request')
-// import MoltinClient from '@moltin/request'
+const { MoltinClient } = require('@moltin/request')
+// import {MoltinClient} from '@moltin/request'
 
 const client = new MoltinClient({
   client_id: '...',
@@ -68,7 +68,7 @@ To prevent unnecessary authentication requests, you will want to use a storage a
 ### Node Local Storage
 
 ```js
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 const NodeStorageAdapter = require('@moltin/node-storage-adapter')
 
 const client = new MoltinClient({
@@ -87,7 +87,7 @@ client
 This library uses [cross-fetch](https://github.com/lquixada/cross-fetch) to make requests. If you wish to change this library, you can pass a custom fetch when instantiating a new moltin client.
 
 ```js
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 const fetchEverywhere = require('fetch-everywhere')
 
 const client = new MoltinClient({
@@ -104,8 +104,8 @@ client
 ## Kitchen sink
 
 ```js
-const MoltinClient = require('@moltin/request')
-// import MoltinClient from '@moltin/request'
+const { MoltinClient } = require('@moltin/request')
+// import {MoltinClient} from '@moltin/request'
 
 const client = new MoltinClient({
   client_id: '...',
@@ -134,7 +134,7 @@ This argument can be used to get products by enabled currency, language or even 
 **Note**: If you add the `Content-Type` custom header to `post`, `put` or `delete` you will need to encode `data` yourself.
 
 ```js
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 
 const client = new MoltinClient({
   client_id: '...'

--- a/examples/apollo-server/index.js
+++ b/examples/apollo-server/index.js
@@ -1,7 +1,7 @@
 const { ApolloServer, gql } = require('apollo-server')
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 
-const moltin = new createClient({
+const moltin = new MoltinClient({
   client_id: 'h93GLWVTdw3EUd9ev7g8Z7ROq54s5JVAzivz9ZrIe1'
 })
 

--- a/examples/apollo-server/index.js
+++ b/examples/apollo-server/index.js
@@ -1,5 +1,5 @@
 const { ApolloServer, gql } = require('apollo-server')
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 
 const moltin = new MoltinClient({
   client_id: 'h93GLWVTdw3EUd9ev7g8Z7ROq54s5JVAzivz9ZrIe1'

--- a/examples/cli-app/index.js
+++ b/examples/cli-app/index.js
@@ -1,8 +1,8 @@
 const meow = require('meow')
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 const ora = require('ora')
 
-const moltin = new createClient({
+const moltin = new MoltinClient({
   client_id: 'h93GLWVTdw3EUd9ev7g8Z7ROq54s5JVAzivz9ZrIe1'
 })
 

--- a/examples/cli-app/index.js
+++ b/examples/cli-app/index.js
@@ -1,5 +1,5 @@
 const meow = require('meow')
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 const ora = require('ora')
 
 const moltin = new MoltinClient({

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 
 const app = express()
 const moltin = new MoltinClient({

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -1,8 +1,8 @@
 const express = require('express')
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 
 const app = express()
-const moltin = new createClient({
+const moltin = new MoltinClient({
   client_id: 'h93GLWVTdw3EUd9ev7g8Z7ROq54s5JVAzivz9ZrIe1'
 })
 

--- a/examples/micro/index.js
+++ b/examples/micro/index.js
@@ -1,9 +1,9 @@
 const { send } = require('micro')
-const { createClient } = require('@moltin/request')
+const MoltinClient = require('@moltin/request')
 
 const { MOLTIN_CLIENT_ID, MOLTIN_CLIENT_SECRET } = process.env
 
-const client = new createClient({
+const client = new MoltinClient({
   client_id: MOLTIN_CLIENT_ID,
   client_secret: MOLTIN_CLIENT_SECRET
 })

--- a/examples/micro/index.js
+++ b/examples/micro/index.js
@@ -1,5 +1,5 @@
 const { send } = require('micro')
-const MoltinClient = require('@moltin/request')
+const { MoltinClient } = require('@moltin/request')
 
 const { MOLTIN_CLIENT_ID, MOLTIN_CLIENT_SECRET } = process.env
 

--- a/examples/next/lib/moltin.js
+++ b/examples/next/lib/moltin.js
@@ -1,5 +1,5 @@
-import { createClient } from '@moltin/request'
+import MoltinClient from '@moltin/request'
 
-export default new createClient({
+export default new MoltinClient({
   client_id: 'h93GLWVTdw3EUd9ev7g8Z7ROq54s5JVAzivz9ZrIe1'
 })

--- a/examples/next/lib/moltin.js
+++ b/examples/next/lib/moltin.js
@@ -1,4 +1,4 @@
-import MoltinClient from '@moltin/request'
+import { MoltinClient } from '@moltin/request'
 
 export default new MoltinClient({
   client_id: 'h93GLWVTdw3EUd9ev7g8Z7ROq54s5JVAzivz9ZrIe1'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch'
 
-import MoltinClient from './'
+import { MoltinClient } from './'
 
 describe('config', () => {
   it('requires a client_id', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,10 @@
 import fetch from 'cross-fetch'
 
-import { createClient } from './'
+import MoltinClient from './'
 
 describe('config', () => {
   it('requires a client_id', async () => {
-    const client = new createClient({ client_id: '' })
+    const client = new MoltinClient({ client_id: '' })
     expect.assertions(1)
 
     try {
@@ -15,7 +15,7 @@ describe('config', () => {
   })
 
   it('cannot authenticate with incorrect client_id', async () => {
-    const client = new createClient({ client_id: 'X' })
+    const client = new MoltinClient({ client_id: 'X' })
     expect.assertions(1)
 
     try {
@@ -26,7 +26,7 @@ describe('config', () => {
   })
 
   it('can fetch using provided fetch library', async () => {
-    const client = new createClient({ client_id: 'X', fetch })
+    const client = new MoltinClient({ client_id: 'X', fetch })
     expect.assertions(1)
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as types from './types'
 import { removeLeadingSlash } from './utils'
 export { createCartIdentifier } from './utils'
 
-export default class MoltinClient {
+export class MoltinClient {
   private client_id: string
   private client_secret?: string
   private storage?: types.StorageFactory

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as types from './types'
 import { removeLeadingSlash } from './utils'
 export { createCartIdentifier } from './utils'
 
-export class createClient {
+export default class MoltinClient {
   private client_id: string
   private client_secret?: string
   private storage?: types.StorageFactory


### PR DESCRIPTION
⚠️ This PR is a breaking change

Old: `import { createClient } from '@moltin/request'`
New: `import { MoltinClient}  from '@moltin/request'`